### PR TITLE
Summaries on legislation list

### DIFF
--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -255,25 +255,22 @@ class SummaryTooltipButton extends Component {
   render() {
     const s = this.props
 
-    let summary = s.summary
-    if (summary) {
-      summary = summary
-                  .replace(/\<p\>\<b\>.*<\/b\>\<\/p\>/, '') // Remove title
-                  .replace(/\<\/?(p|ul|li)\>/g, '') // Remove <p> <ul> or <li> tags
-                  .replace(/\<\/?(b|strong)\>/g, '*') // Replace <b> tags with *
-                  .replace(/"/g, "&#34;") // Escape double quotes
-    }
+    if (!s.summary) { return this.html`` }
+
+    const summary = s.summary
+      .replace(/\<p\>\<b\>.*<\/b\>\<\/p\>/, '') // Remove title
+      .replace(/\<\/?(p|ul|li)\>/g, '') // Remove <p> <ul> or <li> tags
+      .replace(/\<\/?(b|strong)\>/g, '*') // Replace <b> tags with *
+      .replace(/"/g, "&#34;") // Escape double quotes
 
     return this.html`
-      ${ summary ? [`
-        <a href="${`/legislation/${s.short_id}`}" class="is-hidden-mobile">
-          <br />
-          <br />
-          <span class="icon tooltip is-tooltip-left" data-tooltip="${summary}">
-            <i class="fa fa-lg fa-info-circle has-text-grey-lighter"></i>
-          </span>
-        </a>
-      `] : []}
+      <a href="${`/legislation/${s.short_id}`}" class="is-hidden-mobile">
+        <br />
+        <br />
+        <span class="icon tooltip is-tooltip-left" data-tooltip="${summary}">
+          <i class="fa fa-lg fa-info-circle has-text-grey-lighter"></i>
+        </span>
+      </a>
     `
   }
 }

--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -65,6 +65,9 @@ module.exports = class LegislationList extends Component {
               border-color: transparent transparent transparent hsl(0, 0%, 100%) !important;
               left: -1px !important;
             }
+            .tooltip:hover .has-text-grey-lighter {
+              color: hsl(0, 0%, 75%) !important;
+            }
             .highlight-hover:hover {
               background: #f6f8fa;
             }

--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -51,7 +51,8 @@ module.exports = class LegislationList extends Component {
           <link rel="stylesheet" href="/assets/bulma-tooltip.min.css">
           <style>
             .tooltip:hover::before {
-              background: hsl(0, 0%, 92%) !important;
+              background: hsl(0, 0%, 97%) !important;
+              box-shadow: 0px 2px 6px hsla(0, 0%, 0%, 0.25);
               color: black;
               font-size: 14px;
               max-height: 222px;
@@ -60,7 +61,7 @@ module.exports = class LegislationList extends Component {
               width: 400px;
             }
             .tooltip:hover::after {
-              border-color: transparent transparent transparent hsl(0, 0%, 92%) !important;
+              border-color: transparent transparent transparent hsl(0, 0%, 87%) !important;
             }
             .highlight-hover:hover {
               background: #f6f8fa;

--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -180,7 +180,7 @@ class LegislationListRow extends Component {
             </div>
             <div class="column is-one-quarter has-text-right-tablet has-text-left-mobile">
               ${VoteButton.for(this, s, `votebutton-${s.id}`)}
-              ${SummaryTooltipButton.for(this, s, `summarybutton-${s.id}`)}
+              ${s.summary ? SummaryTooltipButton.for(this, s, `summarybutton-${s.id}`) : ''}
             </div>
           </div>
         </div>
@@ -253,21 +253,18 @@ class VoteTally extends Component {
 
 class SummaryTooltipButton extends Component {
   render() {
-    const s = this.props
-
-    if (!s.summary) { return this.html`` }
-
-    const summary = s.summary
+    const { short_id, summary } = this.props
+    const tooltip = summary
       .replace(/\<p\>\<b\>.*<\/b\>\<\/p\>/, '') // Remove title
       .replace(/\<\/?(p|ul|li)\>/g, '') // Remove <p> <ul> or <li> tags
       .replace(/\<\/?(b|strong)\>/g, '*') // Replace <b> tags with *
       .replace(/"/g, "&#34;") // Escape double quotes
 
     return this.html`
-      <a href="${`/legislation/${s.short_id}`}" class="is-hidden-mobile">
+      <a href="${`/legislation/${short_id}`}" class="is-hidden-mobile">
         <br />
         <br />
-        <span class="icon tooltip is-tooltip-left" data-tooltip="${summary}">
+        <span class="icon tooltip is-tooltip-left" data-tooltip="${tooltip}">
           <i class="fa fa-lg fa-info-circle has-text-grey-lighter"></i>
         </span>
       </a>

--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -48,28 +48,52 @@ module.exports = class LegislationList extends Component {
           ${FilterTabs.for(this)}
           ${SearchForm.for(this)}
           ${loading_legislation ? LoadingIndicator.for(this) : legislation.map(o => LegislationListRow.for(this, o, `billitem-${o.id}`))}
-          <link rel="stylesheet" href="/assets/bulma-tooltip.min.css">
           <style>
-            .tooltip:hover::before {
+            .summary-tooltip {
+              position: relative;
+            }
+            .summary-tooltip .summary-tooltip-content {
+              display: none;
+              position: absolute;
+            }
+            .summary-tooltip .summary-tooltip-arrow {
+              display: none;
+              position: absolute;
+            }
+            .summary-tooltip:hover .summary-tooltip-content {
+              display: block;
               background: hsl(0, 0%, 100%) !important;
               box-shadow: 0px 4px 15px hsla(0, 0%, 0%, 0.15);
               border: 1px solid hsl(0, 0%, 87%);
               color: #333;
               font-size: 14px;
-              max-height: 222px;
+              overflow: hidden;
+              padding: .4rem .8rem;
               text-align: left;
               white-space: normal;
               width: 400px;
+              z-index: 99999;
+              top: auto;
+              bottom: 50%;
+              left: auto;
+              right: 100%;
+              transform: translate(-0.5rem, 50%);
             }
-            .tooltip:hover::after {
-              border-color: transparent transparent transparent hsl(0, 0%, 100%) !important;
-              left: -1px !important;
-            }
-            .tooltip:hover .has-text-grey-lighter {
-              color: hsl(0, 0%, 75%) !important;
-            }
-            .highlight-hover:hover {
-              background: #f6f8fa;
+            .summary-tooltip:hover .summary-tooltip-arrow {
+              border-color: transparent transparent transparent hsl(0, 0%, 87%) !important;
+              z-index: 99999;
+              position: absolute;
+              display: inline-block;
+              pointer-events: none;
+              border-style: solid;
+              border-width: .5rem;
+              opacity: 1;
+              margin-left: -.5rem;
+              margin-top: -.5rem;
+              top: 50%;
+              bottom: auto;
+              left: auto;
+              right: calc(100% - .5rem);
             }
           </style>
         </div>
@@ -254,18 +278,17 @@ class VoteTally extends Component {
 class SummaryTooltipButton extends Component {
   render() {
     const { short_id, summary } = this.props
-    const tooltip = summary
-      .replace(/\<p\>\<b\>.*<\/b\>\<\/p\>/, '') // Remove title
-      .replace(/\<\/?(p|ul|li)\>/g, '') // Remove <p> <ul> or <li> tags
-      .replace(/\<\/?(b|strong)\>/g, '*') // Replace <b> tags with *
-      .replace(/"/g, "&#34;") // Escape double quotes
+
+    const summary_truncated = summary.length > 500 ? `${summary.slice(0, 500)} ...` : summary
 
     return this.html`
       <a href="${`/legislation/${short_id}`}" class="is-hidden-mobile">
         <br />
         <br />
-        <span class="icon tooltip is-tooltip-left" data-tooltip="${tooltip}">
+        <span class="icon summary-tooltip">
           <i class="fa fa-lg fa-info-circle has-text-grey-lighter"></i>
+          <div class="summary-tooltip-content">${[summary_truncated]}</div>
+          <div class="summary-tooltip-arrow"></div>
         </span>
       </a>
     `

--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -51,9 +51,10 @@ module.exports = class LegislationList extends Component {
           <link rel="stylesheet" href="/assets/bulma-tooltip.min.css">
           <style>
             .tooltip:hover::before {
-              background: hsl(0, 0%, 97%) !important;
-              box-shadow: 0px 2px 6px hsla(0, 0%, 0%, 0.25);
-              color: black;
+              background: hsl(0, 0%, 100%) !important;
+              box-shadow: 0px 4px 15px hsla(0, 0%, 0%, 0.15);
+              border: 1px solid hsl(0, 0%, 87%);
+              color: #333;
               font-size: 14px;
               max-height: 222px;
               text-align: left;
@@ -61,7 +62,8 @@ module.exports = class LegislationList extends Component {
               width: 400px;
             }
             .tooltip:hover::after {
-              border-color: transparent transparent transparent hsl(0, 0%, 87%) !important;
+              border-color: transparent transparent transparent hsl(0, 0%, 100%) !important;
+              left: -1px !important;
             }
             .highlight-hover:hover {
               background: #f6f8fa;
@@ -265,7 +267,7 @@ class SummaryTooltipButton extends Component {
           <br />
           <br />
           <span class="icon tooltip is-tooltip-left" data-tooltip="${summary}">
-            <i class="fa fa-lg fa-info-circle has-text-grey"></i>
+            <i class="fa fa-lg fa-info-circle has-text-grey-lighter"></i>
           </span>
         </a>
       `] : []}

--- a/components/LegislationList.js
+++ b/components/LegislationList.js
@@ -48,7 +48,14 @@ module.exports = class LegislationList extends Component {
           ${FilterTabs.for(this)}
           ${SearchForm.for(this)}
           ${loading_legislation ? LoadingIndicator.for(this) : legislation.map(o => LegislationListRow.for(this, o, `billitem-${o.id}`))}
+          <link rel="stylesheet" href="/assets/bulma-tooltip.min.css">
           <style>
+            .tooltip:hover::before {
+              background: #000 !important;
+            }
+            .tooltip:hover::after {
+              border-color: #000 transparent transparent transparent !important;
+            }
             .highlight-hover:hover {
               background: #f6f8fa;
             }
@@ -124,6 +131,8 @@ class LegislationListRow extends Component {
     const s = this.props
     const next_action_at = s.next_agenda_action_at || s.next_agenda_begins_at
 
+    const { abstains, nays, yeas } = s
+
     return this.html`
       <div class="card highlight-hover">
         <div class="card-content">
@@ -152,6 +161,14 @@ class LegislationListRow extends Component {
             </div>
             <div class="column is-one-quarter has-text-right-tablet has-text-left-mobile">
               ${VoteButton.for(this, s, `votebutton-${s.id}`)}
+              <div class="is-hidden-mobile">
+                <br />
+              </div>
+              ${ yeas + nays + abstains > 5 ? [`
+                <span class="icon tooltip" data-tooltip="This bill amends the Bank Holding Company Act of 1956 to exempt from the Volcker Rule banks with total assets: (1) of $10 billion or less, and (2) comprised of 5% or less of trading assets and liabilities. (The Volcker Rule prohibits banking agencies from engaging in proprietary trading or entering into certain relationships with hedge funds and private-equity funds.)">
+                  <i class="fa fa-lg fa-info-circle has-text-info"></i>
+                </span>
+              `] : []}
             </div>
           </div>
         </div>


### PR DESCRIPTION
This adds an ℹ️ icon for bills that have a summary. The icon can be hovered over to see a tooltip of the summary, or clicked to go into the full bill page.

![summary-tooltip](https://user-images.githubusercontent.com/6340841/39095937-5a9a59b6-45fd-11e8-9c0c-e5f35bb4dcc1.png)

On mobile, since screen real estate is much tighter, and tooltips don't work all that well with touch screens, a simple `Has summary` line is added to the list of bill info:

![summary-mobile](https://user-images.githubusercontent.com/6340841/39095943-78bb5a76-45fd-11e8-8ff8-15c8a7682e65.png)
